### PR TITLE
Add support for tilde in the token_path parameter of config file Fixes #20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/iancoleman/strcase v0.1.2
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/turbot/go-kit v0.2.2-0.20210628165333-268ba0a30be3
 	github.com/turbot/steampipe-plugin-sdk v1.5.1
 	golang.org/x/oauth2 v0.0.0-20210805134026-6f1e6394065a

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,8 @@ github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW1
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+twI54=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 h1:7GoSOOW2jpsfkntVKaS2rAr1TJqfcxotyaUcuxoZSzg=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 h1:DpOJ2HYzCv8LZP15IdmG+YdwD2luVPHITV96TkirNBM=

--- a/googleworkspace/service.go
+++ b/googleworkspace/service.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/people/v1"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
 )
 
@@ -141,7 +142,15 @@ func getSessionConfig(ctx context.Context, d *plugin.QueryData) ([]option.Client
 
 	// If token path provided, authenticate using OAuth 2.0
 	if tokenPath != "" {
-		opts = append(opts, option.WithCredentialsFile(tokenPath))
+		var path string
+		if tokenPath[0] == '~' {
+			var err error
+			path, err = homedir.Expand(path)
+			if err != nil {
+				return nil, err
+			}
+		}
+		opts = append(opts, option.WithCredentialsFile(path))
 		return opts, nil
 	}
 


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
 select
  summary,
  hangout_link,
  start_time,
  end_time
from
  googleworkspace_calendar_my_event
where
  start_time > now()::timestamp
  and end_time < ('now'::timestamp + interval '1 day');
+---------------------------------+--------------------------------------+----------------------+----------------------+
| summary                         | hangout_link                         | start_time           | end_time             |
+---------------------------------+--------------------------------------+----------------------+----------------------+
| Steampipe - FastFollow          | <null>                               | 2021-12-08T05:45:00Z | 2021-12-08T06:15:00Z |
| Plugin/Mod Release Notes Review | https://meet.google.com/vqa-sdgk-bgc | 2021-12-07T14:30:00Z | 2021-12-07T15:00:00Z |
```
</details>
