### PR TITLE
Recompile plugin with Go version 1.17

### DIFF
--- a/.github/workflows/registry-publish.yml
+++ b/.github/workflows/registry-publish.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.17
 
       - name: Get latest version tag
         run: |-

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/turbot/steampipe-plugin-googleworkspace
 
-go 1.15
+go 1.17
 
 require (
 	github.com/iancoleman/strcase v0.1.2
@@ -8,4 +8,49 @@ require (
 	github.com/turbot/steampipe-plugin-sdk v1.8.2
 	golang.org/x/oauth2 v0.0.0-20210805134026-6f1e6394065a
 	google.golang.org/api v0.54.0
+)
+
+require (
+	cloud.google.com/go v0.90.0 // indirect
+	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
+	github.com/agext/levenshtein v1.2.1 // indirect
+	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/btubbs/datetime v0.1.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/dgraph-io/ristretto v0.1.0 // indirect
+	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/fatih/color v1.7.0 // indirect
+	github.com/gertd/go-pluralize v0.1.7 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/golang/glog v1.0.0 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/hashicorp/go-hclog v0.15.0 // indirect
+	github.com/hashicorp/go-plugin v1.4.1 // indirect
+	github.com/hashicorp/go-version v1.3.0 // indirect
+	github.com/hashicorp/hcl/v2 v2.9.1 // indirect
+	github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb // indirect
+	github.com/mattn/go-colorable v0.1.4 // indirect
+	github.com/mattn/go-isatty v0.0.10 // indirect
+	github.com/mattn/go-runewidth v0.0.7 // indirect
+	github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 // indirect
+	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
+	github.com/mitchellh/mapstructure v1.3.3 // indirect
+	github.com/oklog/run v1.0.0 // indirect
+	github.com/olekukonko/tablewriter v0.0.4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/sethvargo/go-retry v0.1.0 // indirect
+	github.com/stevenle/topsort v0.0.0-20130922064739-8130c1d7596b // indirect
+	github.com/tkrajina/go-reflector v0.5.4 // indirect
+	github.com/zclconf/go-cty v1.8.2 // indirect
+	go.opencensus.io v0.23.0 // indirect
+	golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420 // indirect
+	golang.org/x/sys v0.0.0-20211102061401-a2f17f7b995c // indirect
+	golang.org/x/text v0.3.6 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20210805201207-89edb61ffb67 // indirect
+	google.golang.org/grpc v1.41.0 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/yaml.v2 v2.2.3 // indirect
 )


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
select
  summary,
  hangout_link,
  start_time,
  end_time
from
  googleworkspace_calendar_my_event
where
  start_time > now()::timestamp
  and end_time < ('now'::timestamp + interval '1 day');
+------------------------+--------------+----------------------+----------------------+
| summary                | hangout_link | start_time           | end_time             |
+------------------------+--------------+----------------------+----------------------+
| Steampipe - FastFollow | <null>       | 2021-12-09T05:45:00Z | 2021-12-09T06:15:00Z |
+------------------------+--------------+----------------------+----------------------+
```
</details>
